### PR TITLE
Separate p1 p2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,6 +76,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-playground"
+version = "0.1.0"
+dependencies = [
+ "bincode",
+ "rand",
+ "rsa",
+ "rug",
+ "serde",
+ "sha3",
+]
+
+[[package]]
 name = "der"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -157,18 +169,6 @@ name = "libm"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
-
-[[package]]
-name = "mpc-playground"
-version = "0.1.0"
-dependencies = [
- "bincode",
- "rand",
- "rsa",
- "rug",
- "serde",
- "sha3",
-]
 
 [[package]]
 name = "num-bigint-dig"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "mpc-playground"
+name = "crypto-playground"
 version = "0.1.0"
 edition = "2021"
 

--- a/src/building_block/circuit.rs
+++ b/src/building_block/circuit.rs
@@ -76,7 +76,7 @@ impl Circuit {
       K,
       right_model,
       right_wire,
-       gates,
+      gates,
       wires,
       input_wires,
     );
@@ -85,7 +85,7 @@ impl Circuit {
       out_wire,
       left_wire,
       right_wire,
-      GateType::func(&GateType::And),
+      GateType::func(&gate_type),
       wires,
     );
     gates.create(
@@ -233,7 +233,6 @@ impl Circuit {
     );
 
     let output_decoding_table = OutputDecodingTable::new(
-      root_gate_index,
       root_out_wire,
       &mut wires,
     );

--- a/src/building_block/ot.rs
+++ b/src/building_block/ot.rs
@@ -18,6 +18,20 @@ pub struct OTKeys {
   pub pk_without_sk: PubKey,
 }
 
+pub struct EncryptedWireLabels {
+  pub true_label: Vec<u8>,
+  pub false_label: Vec<u8>,
+}
+
+impl EncryptedWireLabels {
+  pub fn new(
+    true_label: Vec<u8>,
+    false_label: Vec<u8>,
+  ) -> EncryptedWireLabels {
+    EncryptedWireLabels { true_label, false_label }
+  }
+}
+
 impl OT {
   pub fn gen_keys(bits: usize) -> OTKeys {
     let mut rng = rand::thread_rng();
@@ -38,7 +52,7 @@ impl OT {
     true_pub_key: &PubKey,
     false_pub_key: &PubKey,
     wire: &Wire,
-  ) -> (Vec<u8>, Vec<u8>) {
+  ) -> EncryptedWireLabels {
     let mut rng = rand::thread_rng();
 
     let true_wire_label = bincode::serialize(wire.get_label(true)).unwrap();
@@ -54,7 +68,7 @@ impl OT {
         .encrypt(&mut rng, Pkcs1v15Encrypt, &false_wire_label)
         .expect("Failed to encrypt false key");
 
-    (enc_true_wire_label, enc_false_wire_label)
+    EncryptedWireLabels::new(enc_true_wire_label, enc_false_wire_label)
   }
 
   pub fn decrypt(enc_wire_label: &[u8], priv_key: &PrivKey) -> Option<WireLabel> {

--- a/src/building_block/output_decoding_table.rs
+++ b/src/building_block/output_decoding_table.rs
@@ -39,7 +39,6 @@ impl OutputDecodingTable {
   }
 
   pub fn new(
-    gate_id: usize,
     out: usize,
     wires: &Wires,
   ) -> Self {
@@ -58,11 +57,11 @@ impl OutputDecodingTable {
       // compute e
       let e = Self::compute_e(
         &c_label.k,
-        &gate_id,
+        &out.index,
         v_c,
       );
 
-      let index = if e { 1 } else { 0 };
+      let index = out.get_label(v_c).p as usize;
       table[index] = e;
     }
 

--- a/src/building_block/util.rs
+++ b/src/building_block/util.rs
@@ -41,6 +41,23 @@ mod tests {
   use crate::building_block::wire_label::WireLabel;
   use crate::building_block::garbled_table::GarbledTable;
 
+  fn are_vecs_equal(v1: &Vec<u8>, v2: &Vec<u8>) -> bool {
+    let v1_len = v1.len();
+    let v2_len = v2.len();
+    let mut v1 = v1.clone();
+    let mut v2 = v2.clone();
+
+    // Pad the shorter vector with zeros at the end
+    if v1_len < v2_len {
+      let padding = vec![0; v2_len - v1_len];
+      v1.extend(padding);
+    } else if v1_len > v2_len {
+      let padding = vec![0; v1_len - v2_len];
+      v2.extend(padding);
+    }
+    v1 == v2
+  }
+ 
   #[test]
   fn test_get_num_wires() {
     assert!(get_num_wires(0) == 1);  // 2^0 = 1

--- a/src/building_block/wire_label.rs
+++ b/src/building_block/wire_label.rs
@@ -1,7 +1,7 @@
 use crate::building_block::util::gen_random_binary_val;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct WireLabel {
   pub wire_index: usize,
   pub b: bool,

--- a/src/protocols/yao_gc.rs
+++ b/src/protocols/yao_gc.rs
@@ -4,90 +4,179 @@
 use crate::building_block::{
   gate_model::GateModel,
   circuit::Circuit,
-  ot::OT,
+  ot::{
+    EncryptedWireLabels,
+    OT,
+    OTKeys,
+  },
   wire_label::WireLabel,
 };
+use rsa::RsaPublicKey as PubKey;
 
-pub fn run() -> () {
-  /*
+#[derive(Clone)]
+struct Input {
+  index: usize,
+  value: bool,
+}
+
+impl Input {
+  pub fn new(index: usize, value: bool) -> Input {
+    Input { index, value }
+  }
+}
+
+struct P1 {
+  circuit: Circuit,
+  inputs: Vec<Input>,
+}
+
+impl P1 {
+  pub fn new(inputs: Vec<Input>) -> P1 {
+    P1 {
+      circuit: P1::construct_circuit(),
+      inputs,
+    }
+  }
+
+  // P1 constructs circuit with wires and gates
+  // each gate includes a garbled table
+  fn construct_circuit() -> Circuit {
+    /*
    Circuit:
              0|
             (2:Or)
           1/      2\
        (0:And)    (1:Or)
        3/   4\   5/    6\
-       T      F  F       T
 Input: 0      1  2       3
-   */
+    */
+    let gate_model = 
+      GateModel::int_or(
+        GateModel::leaf_and(),
+        GateModel::leaf_or(),
+      );
 
-  // P1 constructs circuit
-  let gate_model = 
-    GateModel::int_or(
-      GateModel::leaf_and(),
-      GateModel::leaf_or(),
+    let K = 64;
+    Circuit::new(&gate_model, K)
+  }
+
+  fn send_encrypted_wire_labels(
+    &self,
+    input_index: usize,
+    ot_true_key: &PubKey,
+    ot_false_key: &PubKey,
+  ) -> EncryptedWireLabels {
+    // encrypt true and false wire labels of the selected input wire
+    let wire = self.circuit.get_input_wire(input_index);
+
+    OT::encrypt_wire_labels(
+      ot_true_key,
+      ot_false_key,
+      wire,
+    )
+  }
+}
+
+struct P2<'a> {
+  circuit: &'a Circuit,
+  inputs: Vec<Input>,
+  ot_keys: OTKeys,
+  circuit_inputs: Vec<WireLabel>,
+}
+
+impl<'a> P2<'a> {
+  pub fn new(
+    circuit: &'a Circuit,
+    inputs: Vec<Input>,
+    p1_input_len: usize,
+  ) -> P2 {
+    let ot_keys = P2::gen_ot_keys();
+    let circuit_inputs: Vec<WireLabel> = vec![
+      WireLabel::default(); 
+      p1_input_len + inputs.len()
+    ];
+
+    P2 {
+      circuit,
+      inputs,
+      ot_keys,
+      circuit_inputs,
+    }
+  }
+
+  pub fn gen_ot_keys() -> OTKeys {
+    let rsa_bits = 1024;
+    OT::gen_keys(rsa_bits)
+  }
+
+  pub fn set_input(&mut self, index: usize, wire_label: WireLabel) {
+    self.circuit_inputs[index] = wire_label;
+  }
+}
+
+pub fn run() -> () {
+  // P1 and P2 are in charge of providing inputs [0, 2] and [1, 3] respectively
+  let p1_inputs = vec![
+    Input::new(0, true),
+    Input::new(2, false),
+  ];
+  let p2_inputs = vec![
+    Input::new(1, false),
+    Input::new(3, true),
+  ];
+
+  let p1 = P1::new(p1_inputs.clone());
+
+  // P1 constructs the circuit with garbled tables and output decoding table
+  // and passes it to P2
+  let mut p2 = P2::new(&p1.circuit, p2_inputs.clone(), p1_inputs.len());
+
+  // P1 sends active wire labels for its inputs to P2
+  for p1_input in p1_inputs {
+    let wire_label: &WireLabel = &p1.circuit
+      .get_input_wire(p1_input.index)
+      .get_label(p1_input.value);
+    p2.circuit_inputs[p1_input.index] = wire_label.clone();
+  }
+
+  // P2 obtaines encrypted active wire labels for its inputs from P1 using OT
+  for p2_input in p2_inputs {
+    // use public key with secret key for the active wire P2 wants to obtain
+    let (true_key, false_key) = {
+      if p2_input.value {
+        (&p2.ot_keys.pk_with_sk, &p2.ot_keys.pk_without_sk)
+      } else {
+        (&p2.ot_keys.pk_without_sk, &p2.ot_keys.pk_with_sk)
+      }
+    };
+
+    // get both of the encrypted wire labels of the wire from P1
+    let enc_wire_labels = p1.send_encrypted_wire_labels(
+      p2_input.index,
+      true_key,
+      false_key,
     );
 
-  let K = 64;
-  let circuit = Circuit::new(&gate_model, K);
+    // P2 decrypts the wire label of its interest
+    let wire_label = OT::decrypt(
+      if p2_input.value {
+        &enc_wire_labels.true_label
+      } else {
+        &enc_wire_labels.false_label
+      },
+      &p2.ot_keys.sk,
+    ).unwrap();
 
-  // P1 has inputs for wire 0 (true) and 1 (false)
-  // P2 has inputs for wire 2 (false) and 3 (true)
- 
-  // P2 gets keys for wire 1 and 3 via OT from P1
-  let rsa_bits = 1024;
-  let ot_keys = OT::gen_keys(rsa_bits);
+    // P2 sets the wire label as its input for the circuit
+    p2.set_input(p2_input.index, wire_label);
+  }
 
-  // P2 gets active input wire for wire 1 and 3 via OT
+  // now P2 has all the inputs to the circuit and evaluates it
+  let root_wire_label = p2.circuit.evaluate(p2.circuit_inputs.iter().collect());
 
-  // P2 sends two public keys to P1 to let P1 encrypt the wire labels
-  // for input wire 1, P2 wants wire label for false
-
-  let wire1_active_label: WireLabel = {
-    // P1 encrypts wire labels of wire 1 and sends them to P2
-    let wire = circuit.get_input_wire(1);
-    let (_, enc_false_wire_label) =
-      OT::encrypt_wire_labels(
-        &ot_keys.pk_without_sk, // true
-        &ot_keys.pk_with_sk,    // false; (P2 needs this)
-        wire,
-      );
-
-    // P2 decrypts false wire label
-    OT::decrypt(&enc_false_wire_label, &ot_keys.sk).unwrap()
-  };
-
-  let wire3_active_label: WireLabel = {
-    // OT of true wire label of wire 3
-
-    // P1 encrypts wire labels of wire 3 and sends them to P2
-    let wire = circuit.get_input_wire(3);
-    let (enc_true_wire_label, _) =
-      OT::encrypt_wire_labels(
-        &ot_keys.pk_with_sk,    // true; (P2 needs this)
-        &ot_keys.pk_without_sk, // false
-        wire,
-      );
-
-    // P2 decrypts true wire label
-    OT::decrypt(&enc_true_wire_label, &ot_keys.sk).unwrap()
-  };
-
-  // P1 sends active label for wire 0 and 2 to P2
-  let wire0_active_label = circuit.get_input_wire(0).get_label(true);
-  let wire2_active_label = circuit.get_input_wire(2).get_label(false);
-
-  // P2 evaluates the circuit with the leaf active labels
-  let root_wire_label = circuit.evaluate(vec![
-    wire0_active_label,
-    &wire1_active_label,
-    wire2_active_label,
-    &wire3_active_label,
-  ]); 
-
-  // P2 gets the active value associated with the root active label
-  // using output_decoding_table
+  // P2 decode the root active wire label to obtain the evaluation result
   let circuit_eval_result =
-    circuit.output_decoding_table.decode(&root_wire_label);
+    p2.circuit.output_decoding_table.decode(&root_wire_label);
 
   assert_eq!(circuit_eval_result, true);
 }


### PR DESCRIPTION
- Create P1 and P2 structs to clearly separate their responsibility
- Replace a mistakenly hardcoded operator enum with a variable
- Assign e to an index p in output decoding table construction